### PR TITLE
Switch to mobile-format blog image for screens under 1024px

### DIFF
--- a/sass/deeplinks.scss
+++ b/sass/deeplinks.scss
@@ -38,7 +38,7 @@ img.deeplinks-thumb {
   object-fit: cover;
   width: 200px;
   height: 200px;
-  @media (max-width: $medium) {
+  @media (max-width: 1023px) {
     width: 100px;
     height: 100px;
   }


### PR DESCRIPTION
Resolves #14 

Fortunately this issue only currently happens on screens between 768px and ~1000px right now! Fixed by shrinking the thumbnail earlier than hiding the text.